### PR TITLE
Make reading of the ZooKeeper configuration file more resilient.

### DIFF
--- a/zktop.py
+++ b/zktop.py
@@ -329,9 +329,15 @@ def sigwinch_handler(*nada):
     resized_sig = True
 
 def read_zk_config(filename):
+    config = {}
     f = open(filename, 'r')
     try:
-        config = dict(tuple(line.rstrip().split('=', 1)) for line in f if line.rstrip())
+        for line in f:
+            if line.rstrip() and not line.startswith('#'):
+                k,v = tuple(line.replace(' ', '').strip().split('=', 1))
+                config[k] = v
+    except IOError as e:
+        print "Unable to open `{0}': I/O error({1}): {2}".format(filename, e.errno, e.strerror)
     finally:
         f.close()
         return config


### PR DESCRIPTION
This is to fix the following problem:

  Traceback (most recent call last):
    File "zktop.py", line 351, in <module>
      ui = Main(get_zk_servers(options.configfile))
    File "zktop.py", line 341, in get_zk_servers
      config = read_zk_config(options.configfile)
    File "zktop.py", line 337, in read_zk_config
      return config
  UnboundLocalError: local variable 'config' referenced before assignment

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
