### PR TITLE
Make resetting remote ZooKeeper server stats more resilient.

### DIFF
--- a/zktop.py
+++ b/zktop.py
@@ -292,7 +292,12 @@ class Main(object):
                         flash = "Help: q:quit r:reset stats spc:refresh"
                         flash_count = 1000/TIMEOUT * 5
                     elif ch == ord('r'):
-                        [reset_server_stats(server) for server in self.servers]
+                        for server in self.servers:
+                            try:
+                                reset_server_stats(server)
+                            except:
+                              pass
+
                         flash = "Server stats reset"
                         flash_count = 1000/TIMEOUT * 5
                         wakeup_poller()


### PR DESCRIPTION
This is to address the following problem:

  Traceback (most recent call last):
    File "/usr/lib/zktop/zktop.py", line 361, in <module>
      curses.wrapper(ui.show_ui)
    File "/usr/lib/python2.6/curses/wrapper.py", line 44, in wrapper
      return func(stdscr, _args, *_kwds)
    File "/usr/lib/zktop/zktop.py", line 297, in show_ui
      [reset_server_stats(server) for server in self.servers]
    File "/usr/lib/zktop/zktop.py", line 141, in reset_server_stats
      send_cmd(host, port, "srst\n")
    File "/usr/lib/zktop/zktop.py", line 110, in send_cmd
      s.connect((host, int(port)))
    File "<string>", line 1, in connect
  socket.error: [Errno 111] Connection refused

Which occurs when a ZooKeeper server is not available.

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
