### PR TITLE
zktop monitoring tool is not working with zookeeper 3.4.X

### DIFF
--- a/zktop.py
+++ b/zktop.py
@@ -81,7 +81,7 @@ class ZKServer(object):
         self.server_id = server_id
         self.host, self.port = server.split(':')
         try:
-            stat = send_cmd(self.host, self.port, 'stat\n')
+            stat = send_cmd(self.host, self.port, 'stat')
 
             sio = StringIO.StringIO(stat)
             line = sio.readline()
@@ -143,7 +143,7 @@ def wakeup_poller():
 
 def reset_server_stats(server):
     host, port = server.split(':')
-    send_cmd(host, port, "srst\n")
+    send_cmd(host, port, "srst")
 
 server_id = 0
 class StatPoller(threading.Thread):


### PR DESCRIPTION
When running against the 3.4.5 and 3.4.6 servers - the tool is trimming the output.
It turns out that the newline char is causing the server to abruptly close the connection with client and only a part of the message is returned.
Removing the newline seems to solve the issue.
Thoughts ?