### PR TITLE
default to using the ZK server’s cfg

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -5,6 +5,7 @@ h1. ZooKeeper top
 h2. Summary
 
 "This project":http://github.com/phunt/zktop provides a unix "top" like utility for ZooKeeper. It is compatible with Python2.6, Python2.7 and Python3.
+With Python2, "pathlib"https://pypi.python.org/pypi/pathlib/ is required to be installed.
 
 h3. Example
 
@@ -62,8 +63,9 @@ Usage: zktop.py [options]
 
 Options:
   -h, --help            show this help message and exit
-  --servers=SERVERS     comma separated list of host:port (default
-                        localhost:2181)
+  --servers=SERVERS     comma separated list of host:port
+                        (default “localhost:2181”, only used if the default
+                        zookeeper configuration file (see --config) is not found)
   -n, --names           resolve session name from ip (default False)
   --fix_330             workaround for a bug in ZK 3.3.0
   -v VERBOSITY, --verbosity=VERBOSITY
@@ -72,7 +74,9 @@ Options:
                         directory in which to place log file, or empty for
                         none
   -c CONFIGFILE, --config=CONFIGFILE
-                        zookeeper configuration file to lookup servers from
+                        zookeeper configuration file to lookup servers from,
+                        ignored if --servers is explicitly specified
+                        (default “/etc/zookeeper/conf/zoo.cfg”)
 </pre>
 
 --fix_330 works around a bug in ZooKeeper 3.3.0, it is only necessary if running the server against that version of ZooKeeper.

--- a/zktop.py
+++ b/zktop.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 from optparse import OptionParser # TODO use argparse instead
+from pathlib import Path
 
 import threading
 import sys
@@ -41,11 +42,12 @@ import curses
     
 
 ZK_DEFAULT_PORT = 2181
+ZK_DEFAULT_CFG = "/etc/zookeeper/conf/zoo.cfg"
 
 usage = "usage: %prog [options]"
 parser = OptionParser(usage=usage)
 parser.add_option("", "--servers",
-                  dest="servers", default="localhost:%s" % ZK_DEFAULT_PORT,
+                  dest="servers", default=None,
                   help="comma separated list of host:port (default localhost:%d)" % ZK_DEFAULT_PORT)
 parser.add_option("-n", "--names",
                   action="store_true", dest="names", default=False,
@@ -60,7 +62,7 @@ parser.add_option("-l", "--logfile",
                   dest="logfile", default=None,
                   help="directory in which to place log file, or empty for none")
 parser.add_option("-c", "--config",
-                  dest="configfile", default=None,
+                  dest="configfile", default="%s" % ZK_DEFAULT_CFG,
                   help="zookeeper configuration file to lookup servers from")
 parser.add_option("-t", "--timeout",
                   dest="timeout", default=None,
@@ -72,6 +74,13 @@ if options.logfile:
     LOG.basicConfig(filename=options.logfile, level=getattr(LOG, options.verbosity))
 else:
     LOG.disable(LOG.CRITICAL)
+
+if options.servers:
+    options.configfile=""
+else:
+    if not Path(options.configfile).is_file():
+        options.servers="localhost:%s" % ZK_DEFAULT_PORT
+        options.configfile=""
 
 resized_sig = False
 


### PR DESCRIPTION
If a ZooKeeper server is installed on the system, zktop is likely expected to
connected to the ZK enseble of that and not only to the local ZK server.

• Set a default path for a ZooKeeper server configuration file to
  "/etc/zookeeper/conf/zoo.cfg".
  This value should be adapted by distributions to their respective ZooKeeper
  server package’s default path.
• Unless “--server” is explicitly given and if the ZooKeeper server
  configuration file exists (is a regular file or a symlink to it) at the
  default path, use the later for determining to which ZooKeeper servers to
  connect.
• Updated the documentation for these changes.
• Added a note that with Python2, zktop now requires pathlib to be installed.

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>